### PR TITLE
Split nyazy to llvm pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Read NyaZy source code from specified input file and compiles it into llvm ir.
 ```bash
 # run the nyacc, generating sample.ll
-$ ./bin/nyac sample.nz
-$ ./bin/nyac sample.nz -o output.ll
+$ ./bin nyac sample.nz
+$ ./bin nyac sample.nz -o output.ll
 # Specify output filename with debug output
-$ ./bin/nyac sample.nz -o output.ll -d
+$ ./bin nyac sample.nz -o output.ll -d --mlir-print-ir-after-all
 # run the LLVM IR using LLVM's lli
 $ ./bin lli sample.ll
 ```

--- a/include/ir/NyaZyOps.td
+++ b/include/ir/NyaZyOps.td
@@ -176,7 +176,7 @@ def CmpOp
   let arguments = (ins NyaZy_CmpPredicateAttr:$predicate,
                        AnyType:$lhs,
                        AnyType:$rhs);
-  let results = (outs UI1);
+  let results = (outs I1);
 
   let extraClassDeclaration = [{
     static std::optional<nyacc::CmpPredicate> getPredicateByName(mlir::StringRef name);
@@ -566,7 +566,7 @@ def ConditionOp : NyaZyOp<"condition", [
     to the entry block of the region. Otherwise, the loop terminates.
   }];
 
-  let arguments = (ins UI1:$condition);
+  let arguments = (ins I1:$condition);
 
   let assemblyFormat =
       [{ `(` $condition `)` attr-dict  }];

--- a/include/ir/Pass.h
+++ b/include/ir/Pass.h
@@ -6,6 +6,11 @@ class Pass;
 
 namespace nyacc {
 
-std::unique_ptr<mlir::Pass> createNyaZyToLLVMPass();
+// Lower NyaZy dialect to standard dialects: arith, memref, scf, func, except for `nyazy.print`
+std::unique_ptr<mlir::Pass> createNyaZyToStdPass();
+// Lower standard dialects(arith, memref, scf, func) to LLVM dialect
+std::unique_ptr<mlir::Pass> createStdToLLVMPass();
+// Lower `nyazy.print` to LLVM printf
+std::unique_ptr<mlir::Pass> createNyaZyPrintToLLVMPass();
 
 } // nyacc

--- a/include/ir/common.h
+++ b/include/ir/common.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/PatternMatch.h>
+
+namespace nyacc {
+
+// Helper function to get or create a format string global variable
+mlir::Value getOrCreateGlobalString(mlir::Location loc, mlir::ModuleOp module,
+                                    mlir::PatternRewriter &rewriter,
+                                    llvm::StringRef formatStr);
+
+} // namespace nyacc

--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -2,7 +2,10 @@ target_sources(NyaZyDialect PRIVATE
     NyaZyDialect.cpp
     NyaZyOpsEnums.cpp
     NyaZyOps.cpp
-    lowerToLLVM.cpp
+    lowerNyaZyPrintToPrintf.cpp
+    lowerNyaZyToStd.cpp
+    lowerStdToLLVM.cpp
+    common.cpp
 )
 
 target_link_libraries(NyaZyDialect

--- a/src/ir/common.cpp
+++ b/src/ir/common.cpp
@@ -1,0 +1,40 @@
+// Helper function to get or create a format string global variable
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/IR/Value.h>
+
+namespace nyacc {
+mlir::Value getOrCreateGlobalString(mlir::Location loc, mlir::ModuleOp module,
+                                    mlir::PatternRewriter &rewriter,
+                                    llvm::StringRef formatStr) {
+  mlir::LLVM::GlobalOp globalStr;
+
+  // Use the format string as the global variable name
+  std::string globalName = "global_str_" + std::to_string(std::hash<std::string>{}(formatStr.str()));
+
+  if (!(globalStr = module.lookupSymbol<mlir::LLVM::GlobalOp>(globalName))) {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(module.getBody());
+
+    mlir::Type i8Type = mlir::IntegerType::get(rewriter.getContext(), 8);
+    mlir::Type strType = mlir::LLVM::LLVMArrayType::get(i8Type, formatStr.size() + 1);
+
+    globalStr = rewriter.create<mlir::LLVM::GlobalOp>(
+        loc, strType, /*isConstant=*/true, mlir::LLVM::Linkage::Internal,
+        globalName, rewriter.getStringAttr(formatStr.str() + '\0'));
+  }
+
+  // Get a pointer to the first character in the global string
+  mlir::Type i8PtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+
+  mlir::Value globalPtr = rewriter.create<mlir::LLVM::AddressOfOp>(loc, globalStr);
+  mlir::Value zero = rewriter.create<mlir::LLVM::ConstantOp>(
+      loc, rewriter.getI64Type(), rewriter.getI64IntegerAttr(0));
+  mlir::Value ptr = rewriter.create<mlir::LLVM::GEPOp>(
+      loc, i8PtrType, globalStr.getType(), globalPtr, mlir::ValueRange{zero, zero});
+
+  return ptr;
+}
+
+} // namespace nyacc

--- a/src/ir/lowerNyaZyPrintToPrintf.cpp
+++ b/src/ir/lowerNyaZyPrintToPrintf.cpp
@@ -1,0 +1,157 @@
+#include "ir/common.h"
+#include "ir/Pass.h"
+#include "ir/NyaZyDialect.h"
+#include "ir/NyaZyOps.h"
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
+#include <mlir/IR/BuiltinDialect.h>
+
+namespace {
+
+
+// Helper function to get or insert the 'printf' function declaration
+mlir::LLVM::LLVMFuncOp getOrInsertPrintf(mlir::ModuleOp module, mlir::PatternRewriter &rewriter) {
+  auto printfFunc = module.lookupSymbol<mlir::LLVM::LLVMFuncOp>("printf");
+  if (printfFunc) {
+    return printfFunc;
+  }
+
+  // Create 'printf' function declaration
+  mlir::OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(module.getBody());
+
+  mlir::Type i8PtrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+
+  auto printfType = mlir::LLVM::LLVMFunctionType::get(
+      mlir::IntegerType::get(rewriter.getContext(), 32),
+      {i8PtrType}, /*isVarArg=*/true);
+
+  printfFunc = rewriter.create<mlir::LLVM::LLVMFuncOp>(
+      rewriter.getUnknownLoc(), "printf", printfType);
+
+  return printfFunc;
+}
+
+
+struct PrintIntOpLowering : public mlir::OpConversionPattern<nyacc::PrintOp> {
+  using mlir::OpConversionPattern<nyacc::PrintOp>::OpConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      nyacc::PrintOp op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter &rewriter) const override {
+    // Check if the operand is an integer type
+    auto operandType = adaptor.getOperand().getType();
+    if (!llvm::isa<mlir::IntegerType>(operandType)) {
+      return mlir::failure();
+    }
+
+    mlir::Location loc = op.getLoc();
+    mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+
+    // Get or create the printf function declaration
+    auto printfFunc = getOrInsertPrintf(module, rewriter);
+
+    // Get or create the format string for integers
+    auto formatStrPtr = nyacc::getOrCreateGlobalString(loc, module, rewriter, "%ld\n");
+
+    // Ensure the operand is of LLVM integer type (i64)
+    mlir::Value value = adaptor.getOperand();
+
+    // Create the printf call
+    auto callop = rewriter.create<mlir::LLVM::CallOp>(
+      loc,
+        mlir::TypeRange{mlir::IntegerType::get(rewriter.getContext(), 32)},
+        mlir::SymbolRefAttr::get(printfFunc),
+        mlir::ValueRange{formatStrPtr, value});
+    
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    mlir::Type printfType = mlir::LLVM::LLVMFunctionType::get(
+        mlir::IntegerType::get(rewriter.getContext(), 32),
+        {ptrType}, /*isVarArg=*/true);
+    callop->setAttr("var_callee_type", mlir::TypeAttr::get(printfType));
+
+    rewriter.eraseOp(op);
+
+    return mlir::success();
+  }
+};
+
+struct PrintStringOpLowering : public mlir::OpConversionPattern<nyacc::PrintOp> {
+  using mlir::OpConversionPattern<nyacc::PrintOp>::OpConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(
+      nyacc::PrintOp op, OpAdaptor adaptor,
+      mlir::ConversionPatternRewriter &rewriter) const override {
+    // Check if the operand is an LLVM pointer to i8 (string)
+    auto operandType = adaptor.getOperand().getType();
+    auto llvmPtrType = llvm::dyn_cast<mlir::LLVM::LLVMPointerType>(operandType);
+    if (!llvmPtrType) {
+      return mlir::failure();
+    }
+
+    mlir::Location loc = op.getLoc();
+    mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+
+    // Get or create the printf function declaration
+    auto printfFunc = getOrInsertPrintf(module, rewriter);
+
+    // Get or create the format string for strings
+    auto formatStrPtr = nyacc::getOrCreateGlobalString(loc, module, rewriter, "%s\n");
+
+    // Create the printf call
+    auto callop = rewriter.create<mlir::LLVM::CallOp>(
+        loc,
+        mlir::TypeRange{mlir::IntegerType::get(rewriter.getContext(), 32)},
+        mlir::SymbolRefAttr::get(printfFunc),
+        mlir::ValueRange{formatStrPtr, adaptor.getOperand()}
+    );
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    mlir::Type printfType = mlir::LLVM::LLVMFunctionType::get(
+        mlir::IntegerType::get(rewriter.getContext(), 32),
+        {ptrType}, /*isVarArg=*/true);
+    callop->setAttr("var_callee_type", mlir::TypeAttr::get(printfType));
+
+    rewriter.eraseOp(op);
+
+    return mlir::success();
+  }
+};
+
+// Lower standard dialects(arith, memref, scf, func) to LLVM dialect
+class StdToLLVMPass : public mlir::PassWrapper<StdToLLVMPass, mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StdToLLVMPass)
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<nyacc::NyaZyDialect, mlir::arith::ArithDialect, mlir::memref::MemRefDialect, mlir::scf::SCFDialect, mlir::func::FuncDialect>();
+  }
+
+private:
+  void runOnOperation() final;
+};
+} // namespace
+
+void StdToLLVMPass::runOnOperation() {
+  // Lowering for nyazy.print -> LLVM printf
+  mlir::ConversionTarget printTarget(getContext());
+  printTarget.addLegalDialect<mlir::BuiltinDialect, mlir::LLVM::LLVMDialect>();
+  printTarget.addIllegalOp<nyacc::PrintOp>();
+
+  mlir::RewritePatternSet printPatterns(&getContext());
+  printPatterns.add<PrintIntOpLowering, PrintStringOpLowering>(&getContext());
+
+  if (failed(
+          applyFullConversion(getOperation(), printTarget, std::move(printPatterns)))) {
+    signalPassFailure();
+  }
+
+}
+
+// Lower `nyazy.print` to LLVM printf
+std::unique_ptr<mlir::Pass> nyacc::createNyaZyPrintToLLVMPass() {
+  return std::make_unique<StdToLLVMPass>();
+}

--- a/src/ir/lowerStdToLLVM.cpp
+++ b/src/ir/lowerStdToLLVM.cpp
@@ -1,0 +1,91 @@
+#include "ir/NyaZyDialect.h"
+#include "ir/Pass.h"
+#include "ir/NyaZyOps.h"
+#include <mlir/IR/BuiltinDialect.h>
+#include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>
+#include <mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h>
+#include <mlir/Conversion/LLVMCommon/TypeConverter.h>
+#include <mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h>
+#include <mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h>
+#include <mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/MemRef/IR/MemRef.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
+
+namespace {
+// Lower standard dialects(arith, memref, scf, func) to LLVM dialect
+class StdToLLVMPass : public mlir::PassWrapper<StdToLLVMPass, mlir::OperationPass<mlir::ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(StdToLLVMPass)
+  void getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<nyacc::NyaZyDialect>();
+  }
+
+private:
+  void runOnOperation() final;
+};
+} // namespace
+
+void StdToLLVMPass::runOnOperation() {
+  mlir::ConversionTarget target(getContext());
+  target.addLegalDialect<mlir::BuiltinDialect, mlir::LLVM::LLVMDialect, mlir::memref::MemRefDialect>();
+  target.addIllegalDialect<mlir::arith::ArithDialect, mlir::func::FuncDialect, mlir::scf::SCFDialect>();
+  target.addLegalOp<nyacc::PrintOp>();
+
+  mlir::RewritePatternSet patterns(&getContext());
+
+  // * -> llvm
+  mlir::LLVMTypeConverter typeConverter(&getContext());
+  mlir::arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
+  mlir::populateFuncToLLVMConversionPatterns(typeConverter, patterns);
+  mlir::populateSCFToControlFlowConversionPatterns(patterns);
+  mlir::cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
+
+  if (failed(
+          applyFullConversion(getOperation(), target, std::move(patterns)))) {
+    signalPassFailure();
+  }
+
+  // scf -> llvm
+  mlir::ConversionTarget scfTarget(getContext());
+  mlir::LLVMTypeConverter scfTypeConverter(&getContext());
+  scfTarget.addLegalDialect<mlir::BuiltinDialect, mlir::LLVM::LLVMDialect, mlir::memref::MemRefDialect>();
+  scfTarget.addLegalOp<nyacc::PrintOp>();
+  scfTarget.addIllegalDialect<mlir::scf::SCFDialect>();
+
+  mlir::RewritePatternSet scfPatterns(&getContext());
+  mlir::populateSCFToControlFlowConversionPatterns(scfPatterns);
+  mlir::cf::populateControlFlowToLLVMConversionPatterns(scfTypeConverter, scfPatterns);
+
+  if (failed(
+          applyFullConversion(getOperation(), scfTarget, std::move(scfPatterns)))) {
+    signalPassFailure();
+  }
+
+  // memref -> llvm
+  mlir::ConversionTarget target2(getContext());
+  target2.addLegalDialect<mlir::BuiltinDialect, mlir::LLVM::LLVMDialect>();
+  target2.addLegalOp<nyacc::PrintOp>();
+  target2.addIllegalDialect<mlir::memref::MemRefDialect>();
+
+  mlir::RewritePatternSet patterns2(&getContext());
+
+  mlir::LLVMTypeConverter typeConverter2(&getContext());
+
+  mlir::populateFinalizeMemRefToLLVMConversionPatterns(typeConverter2, patterns2);
+
+  if (failed(
+          applyFullConversion(getOperation(), target2, std::move(patterns2)))) {
+    signalPassFailure();
+  }
+}
+
+// Lower standard dialects(arith, memref, scf, func) to LLVM dialect
+std::unique_ptr<mlir::Pass> nyacc::createStdToLLVMPass() {
+  return std::make_unique<StdToLLVMPass>();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,9 @@ int main(int argc, char **argv) {
   }
 
   mlir::PassManager pm(&context);
-  pm.addPass(nyacc::createNyaZyToLLVMPass());
+  pm.addPass(nyacc::createNyaZyToStdPass());
+  pm.addPass(nyacc::createStdToLLVMPass());
+  pm.addPass(nyacc::createNyaZyPrintToLLVMPass());
 
   if (mlir::failed(pm.run(*module))) {
     llvm::errs() << "Failed to lower to LLVM IR\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinDialect.h"
@@ -48,6 +49,9 @@ std::string readFile(const std::string &filename) {
 }
 
 int main(int argc, char **argv) {
+  mlir::registerAsmPrinterCLOptions();
+  mlir::registerMLIRContextCLOptions();
+  mlir::registerPassManagerCLOptions();
   llvm::cl::opt<std::string> inputFileName(
       llvm::cl::Positional, llvm::cl::desc("<input file>"), llvm::cl::Required);
   llvm::cl::opt<std::string> outputFileName(
@@ -122,7 +126,11 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  mlir::PassManager pm(&context);
+  mlir::PassManager pm(&context, module.get()->getName().getStringRef());
+  if (mlir::failed(mlir::applyPassManagerCLOptions(pm))) {
+    llvm::errs() << "Failed to apply pass manager command line options.\n";
+    return 1;
+  }
   pm.addPass(nyacc::createNyaZyToStdPass());
   pm.addPass(nyacc::createStdToLLVMPass());
   pm.addPass(nyacc::createNyaZyPrintToLLVMPass());


### PR DESCRIPTION
 * Split into 3 passes
```cpp
// Lower NyaZy dialect to standard dialects: arith, memref, scf, func, except for `nyazy.print`
std::unique_ptr<mlir::Pass> createNyaZyToStdPass();
// Lower standard dialects(arith, memref, scf, func) to LLVM dialect
std::unique_ptr<mlir::Pass> createStdToLLVMPass();
// Lower `nyazy.print` to LLVM printf
std::unique_ptr<mlir::Pass> createNyaZyPrintToLLVMPass();
```